### PR TITLE
added GoalPageContext.tsx and refactored GoalPage to use the context …

### DIFF
--- a/frontend/src/pages/GoalPage/GoalPage.tsx
+++ b/frontend/src/pages/GoalPage/GoalPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useContext } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { GoalObj, TaskObj, FunctionAny } from "@shared/types/general";
 
@@ -28,19 +28,37 @@ import MinimalisticTextArea from "../../components/MinimalisticTextArea/Minimali
 import styles from "./GoalPage.module.css";
 import useTutorialWithDialog from "../../hooks/UseTutorialWithDialog/useTutorialWithDialog";
 import { FaRegQuestionCircle } from "react-icons/fa";
+import { GoalPageContext, GoalPageProvider } from "./GoalPageContext";
 
-export default function GoalPage() {
+export default function GoalPageWithContext(){
+  return(
+  <GoalPageProvider>
+    <GoalPage/>
+  </GoalPageProvider>
+  )
+}
+
+
+export function GoalPage() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const [saving, setSaving] = useState(false);
-  const [changed, setChanged] = useState(false);
   const [params, _] = useSearchParams();
-  const [goal, setGoal] = useState<GoalObj | boolean | undefined>(undefined);
   const originalGoal = useRef<GoalObj | boolean | undefined>({});
-  const [goalOwner, setGoalOwner] = useState<ClientSocketUser | boolean>();
   const id = params.get("id");
   const newParam = params.get("new");
   const isNew = newParam == "true";
+
+  const {
+    saving, 
+    setSaving, 
+    changed, 
+    setChanged, 
+    goal, 
+    setGoal, 
+    goalOwner, 
+    setGoalOwner
+  } = useContext(GoalPageContext)
+
   const { user: self, ready } = useSelector(
     (store: ReduxRootState) => store.ClientSocket
   );

--- a/frontend/src/pages/GoalPage/GoalPage.tsx
+++ b/frontend/src/pages/GoalPage/GoalPage.tsx
@@ -135,11 +135,6 @@ export function GoalPage() {
 
   const selfIsOwner = self.id == goalOwner.id;
 
-  const setTasks = (tasks: TaskObj[]) => {
-    setGoal({ ...goal, tasks });
-    setChanged(true);
-  };
-
   const setGoalName = (name: string) => {
     setGoal({ ...goal, name });
     setChanged(true);
@@ -215,7 +210,7 @@ export function GoalPage() {
     );
   };
 
-  const { name, tasks } = goal;
+  const { name } = goal;
   const { fName, mName, lName } = goalOwner;
 
   const handleOnBack = () => {
@@ -277,8 +272,8 @@ export function GoalPage() {
         <div style={{ marginLeft: 10 }}>
           <TasksSection
             disabled={!selfIsOwner}
-            tasks={tasks}
-            setTasks={setTasks}
+            // tasks={tasks}
+            // setTasks={setTasks}
           />
         </div>
       </div>
@@ -295,25 +290,36 @@ export function GoalPage() {
 }
 
 function TasksSection({
-  tasks,
-  setTasks,
   disabled,
 }: {
-  tasks?: TaskObj[];
-  setTasks: Function;
   disabled: boolean;
 }) {
+  const {goal,setGoal,setChanged} = useContext(GoalPageContext)
   const dispatch = useDispatch();
+  // type guard for tasks
+  if (typeof goal === "boolean" || !goal){
+    return null;
+  }
+
+  const { tasks } = goal;
+
+  const setTasks = (tasks: TaskObj[]) => {
+    setGoal({ ...goal, tasks });
+    setChanged(true);
+  };
+
   function handleAddTask() {
     const newTasks = [...(tasks || [])];
     const newTask: TaskObj = {
       name: "New Task",
       description: "Task description",
     };
+    
     newTasks.push(newTask);
     setTasks(newTasks);
   }
 
+  
   function handleEditTask(tIndex: number, newTask: TaskObj) {
     if (!tasks) {
       return;

--- a/frontend/src/pages/GoalPage/GoalPageContext.tsx
+++ b/frontend/src/pages/GoalPage/GoalPageContext.tsx
@@ -1,0 +1,47 @@
+import { GoalObj } from "@shared/types/general";
+import { ClientSocketUser } from "../../features/ClientSocket/ClientSocket";
+import { createContext, useState, ReactNode} from "react";
+
+type GoalPageType = {
+    saving: boolean;
+    setSaving: (v:boolean)=> void;
+    changed: boolean;
+    setChanged:(v:boolean)=> void;
+    goal: GoalObj | boolean | undefined;
+    setGoal: (v:GoalObj | boolean | undefined) => void;
+    goalOwner: ClientSocketUser | boolean | undefined;
+    setGoalOwner: (v:ClientSocketUser | boolean | undefined) => void;
+};
+
+export const GoalPageContext = createContext<GoalPageType>({
+    saving:false,
+    setSaving:(_)=>{},
+    changed:false,
+    setChanged:(_)=>{},
+    goal:undefined,
+    setGoal:(_)=>{},
+    goalOwner:undefined,
+    setGoalOwner:(_)=>{},
+});
+export const GoalPageProvider = ({children}: {children:ReactNode}) =>{
+    const [saving, setSaving] = useState(false);
+    const [changed, setChanged] = useState(false);
+    const [goal, setGoal] = useState<GoalObj | boolean | undefined>(undefined);
+    const [goalOwner, setGoalOwner] = useState<ClientSocketUser | boolean>();
+
+    return(
+        <GoalPageContext.Provider value={{
+            saving, 
+            setSaving, 
+            changed, 
+            setChanged, 
+            goal, 
+            setGoal, 
+            goalOwner, 
+            setGoalOwner
+        }}
+        >
+            {children}
+        </GoalPageContext.Provider>
+    )
+} 


### PR DESCRIPTION
## issue
- #23 
- the `GoalPage` used prop drilling to get it's data, now it utilizes the `GoalPageContext.tsx` to get it's data 
## changes 
- created `GoalPageContext.tsx` and migrated states from `GoalPage` to the new file.
- wrapped `GoalPage` with its `GoalPageProvider` to provide it's data
### personal issue
- i had to add `'..'` to the `vite.config.ts' to be able to run the site, but didn't push those changes